### PR TITLE
Update "Properties of integers" to "Basic Algebra"

### DIFF
--- a/data/Concept Sentences for SAT Diagnostic - Math.csv
+++ b/data/Concept Sentences for SAT Diagnostic - Math.csv
@@ -1,6 +1,6 @@
 Concept,Text
 Definition of Functions,"Defining functions is the single most important skill to master if you want to do well on the SAT, and the SAT really tries to test you on the concept from every different angle. In particular, you're going to have to master the ability to pull functions and their corresponding numbers out of word problems. "
-Properties of Integers,"The properties of integers are pretty foundational concepts that underpin a lot of math techniques, so if you shore this up, it will pay dividends for many other types of questions. "
+Basic Algebra,"Basic algebra contains foundational concepts that underpin a lot of math techniques, so if you shore this up, it will pay dividends for many other types of questions. "
 Statistics,"The SAT has really ramped up its testing of basic statistical concepts, particularly looking at ""real-world"" datasets that are used to test the basics of mean, median, and mode. One thing you should watch out for on these types of questions is whether the numbers are out of order - the SAT writers will try to trick you with that. "
 Equation of a Line,"The questions that involve the equation of a line are mainly testing slope-intercept format, so if you've got limited time, you should focus on mastering that before you work on point-slope format. "
 System of Equations,The systems of equations questions on the SAT tend to involve relatively simple math but the complexity usually comes from having to generate a system of equations from a paragraph of text in a word problem

--- a/data/Data Assets - Math1-ans.csv
+++ b/data/Data Assets - Math1-ans.csv
@@ -1,7 +1,7 @@
 question,answer,difficulty,concept,concept2,explain
-1,D,1,Properties of Integers,,"data/math1/1.txt"
+1,D,1,Basic Algebra,,"data/math1/1.txt"
 2,A,1,Equation of a Line,,"data/math1/2.txt"
-3,A,1,Properties of Integers,,"data/math1/3.txt"
+3,A,1,Basic Algebra,,"data/math1/3.txt"
 4,C,2,Triangles,Interior Angles of a Polygon,"data/math1/4.txt"
 5,B,2,Angles & Lines,,"data/math1/5.txt"
 6,B,1,Systems of Inequalities,,"data/math1/6.txt"

--- a/data/Data Assets - Math2-ans.csv
+++ b/data/Data Assets - Math2-ans.csv
@@ -1,7 +1,7 @@
 question,answer,difficulty,concept,concept2,explain
-1,A,1,Properties of Integers,,data/math2/1.txt
+1,A,1,Basic Algebra,,data/math2/1.txt
 2,C,1,Definition of Functions,,data/math2/2.txt
-3,A,1,Properties of Integers,,data/math2/3.txt
+3,A,1,Basic Algebra,,data/math2/3.txt
 4,C,2,Equation of a Line,Statistics,data/math2/4.txt
 5,B,2,Parallel & Perpendicular lines,Angles & Lines,data/math2/5.txt
 6,D,1,System of Equations,,data/math2/6.txt
@@ -9,10 +9,10 @@ question,answer,difficulty,concept,concept2,explain
 8,B,3,Exponents,Complex Equations,data/math2/8.txt
 9,D,2,Angles & Lines,,data/math2/9.txt
 10,D,4,Equation of a Line,Definition of Functions,data/math2/10.txt
-11,B,1,Properties of Integers,,data/math2/11.txt
+11,B,1,Basic Algebra,,data/math2/11.txt
 12,C,1,Systems of Inequalities,,data/math2/12.txt
 13,C,3,Exponents,Complex Equations,data/math2/13.txt
-14,D,2,Properties of Integers,,data/math2/14.txt
+14,D,2,Basic Algebra,,data/math2/14.txt
 15,D,2,Angles & Lines,,data/math2/15.txt
 16,B,1,Definition of Functions,,data/math2/16.txt
 17,A,1,Statistics,,data/math2/17.txt
@@ -29,10 +29,10 @@ question,answer,difficulty,concept,concept2,explain
 28,D,2,Statistics,,data/math2/28.txt
 29,B,2,Equation of a Line,,data/math2/29.txt
 30,B,3,Definition of Functions,,data/math2/30.txt
-31,96,1,Properties of Integers,,data/math2/31.txt
-32,9,1,Properties of Integers,,data/math2/32.txt
+31,96,1,Basic Algebra,,data/math2/31.txt
+32,9,1,Basic Algebra,,data/math2/32.txt
 33,16,2,System of Equations,,data/math2/33.txt
-34,0.3,2,Properties of Integers,,data/math2/34.txt
+34,0.3,2,Basic Algebra,,data/math2/34.txt
 35,6 or 2,2,System of Equations,Definition of Functions,data/math2/35.txt
 36,0,5,"Sin, Cos, & Tan",,data/math2/36.txt
 37,696,2,Definition of Functions,,data/math2/37.txt


### PR DESCRIPTION
This PR updates the "Properties of Integers" concept tag to the new name: "Basic Algebra." This change is necessary to align the automated diagnostic tool with the remainder of the SAT materials.